### PR TITLE
Do not access OpenPub post types before registration

### DIFF
--- a/src/rest_api/class-openpub-controller.php
+++ b/src/rest_api/class-openpub-controller.php
@@ -59,8 +59,7 @@ class Openpub_Controller extends \WP_REST_Posts_Controller {
 			return;
 		}
 
-		// Note: Below we make sure that we don't call the constructor before
-		//       the OpenPub plugin registered its post types
+		// Note: Below we make sure that we don't call the constructor before the OpenPub plugin registered its post types.
 		add_action( 'init', [ $this, 'init' ], 11 );
 
 		add_action( 'rest_api_init', [ $this, 'register_routes' ] );


### PR DESCRIPTION
Ran into this issue where the `openpub-item` post type was accessed before it was registered. This change fixes that issue, but I'm note sure of any side effects of delaying the call to the constructor. Please double check.